### PR TITLE
add api key environment

### DIFF
--- a/nearquake/open_ai_client.py
+++ b/nearquake/open_ai_client.py
@@ -1,10 +1,11 @@
 import logging
+import os
 
 from openai import OpenAI
 
 _logger = logging.getLogger(__name__)
 
-client = OpenAI()
+client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 
 
 def generate_response(


### PR DESCRIPTION
Fix the below error: 


```
openai.OpenAIError: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable 
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced security by initializing the `client` object with the API key from environment variables instead of hardcoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->