### PR TITLE
Potential fix for code scanning alert no. 1485: Clear-text logging of sensitive information

### DIFF
--- a/nearquake/data_processor.py
+++ b/nearquake/data_processor.py
@@ -229,7 +229,7 @@ class UploadEarthQuakeLocation(BaseDataUploader):
 
         except Exception as e:
             _logger.error(
-                f"Encountered an error while attempting to extract long, and lattiude {e} content: {content} event {event}  url: {url}"
+                f"Encountered an error while attempting to extract location details: {e}"
             )
         return None
 


### PR DESCRIPTION
Potential fix for [https://github.com/dachosen1/nearquake/security/code-scanning/1485](https://github.com/dachosen1/nearquake/security/code-scanning/1485)

To fix the problem, we need to ensure that sensitive information such as latitude and longitude is not logged in clear text. Instead, we can log a generic message that indicates an error occurred without revealing the sensitive details. This can be achieved by modifying the logging statements to exclude sensitive data.

Specifically, we will:
1. Modify the logging statement on line 232 in `nearquake/data_processor.py` to remove the sensitive data.
2. Ensure that the new logging statement still provides useful information for debugging without exposing sensitive details.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
