### PR TITLE
Potential fix for code scanning alert no. 1484: Clear-text logging of sensitive information

### DIFF
--- a/nearquake/data_processor.py
+++ b/nearquake/data_processor.py
@@ -211,9 +211,7 @@ class UploadEarthQuakeLocation(BaseDataUploader):
             return None
 
         if content.get("error") is not None:
-            _logger.error(
-                "Unable to get geocode due to an error."
-            )
+            _logger.error("Unable to get geocode due to an error.")
 
         try:
             return LocationDetails(

--- a/nearquake/data_processor.py
+++ b/nearquake/data_processor.py
@@ -212,7 +212,7 @@ class UploadEarthQuakeLocation(BaseDataUploader):
 
         if content.get("error") is not None:
             _logger.error(
-                f"unable to get geocode for {event} content: {content} due to {content.get('error')} error "
+                f"Unable to get geocode due to {content.get('error')} error."
             )
 
         try:
@@ -229,7 +229,7 @@ class UploadEarthQuakeLocation(BaseDataUploader):
 
         except Exception as e:
             _logger.error(
-                f"Encountered an error while attempting to extract long, and lattiude {e} content: {content} event {event}  url: {url}"
+                f"Encountered an error while attempting to extract location details: {e}"
             )
         return None
 

--- a/nearquake/data_processor.py
+++ b/nearquake/data_processor.py
@@ -212,7 +212,7 @@ class UploadEarthQuakeLocation(BaseDataUploader):
 
         if content.get("error") is not None:
             _logger.error(
-                f"Unable to get geocode due to {content.get('error')} error."
+                "Unable to get geocode due to an error."
             )
 
         try:


### PR DESCRIPTION
Potential fix for [https://github.com/dachosen1/nearquake/security/code-scanning/1484](https://github.com/dachosen1/nearquake/security/code-scanning/1484)

To fix the problem, we need to ensure that sensitive information such as latitude, longitude, and other potentially sensitive data are not logged in clear text. Instead, we can log a more generic message that does not include sensitive details. 

The best way to fix the problem without changing existing functionality is to modify the log messages to exclude sensitive information. Specifically, we will update the log message on line 215 to remove the `event` and `content` details and provide a more generic error message.

We will make the following changes in the `nearquake/data_processor.py` file:
- Update the log message on line 215 to exclude sensitive information.
- Update the log message on line 232 to exclude sensitive information.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
