### PR TITLE
Potential fix for code scanning alert no. 1478: Clear-text logging of sensitive information

### DIFF
--- a/nearquake/utils/__init__.py
+++ b/nearquake/utils/__init__.py
@@ -165,7 +165,7 @@ def fetch_json_data_from_url(url):
             return json.loads(response.text)
 
         except json.JSONDecodeError:
-            _logger.error(f"Failed to decode JSON from response: {response.text}")
+            _logger.error("Failed to decode JSON from the response.")
             return None
 
     except requests.exceptions.HTTPError as e:


### PR DESCRIPTION
Potential fix for [https://github.com/dachosen1/nearquake/security/code-scanning/1478](https://github.com/dachosen1/nearquake/security/code-scanning/1478)

To fix the problem, we should avoid logging the entire response text when a JSON decoding error occurs. Instead, we can log a more generic error message that does not include the potentially sensitive response content. This way, we still capture the occurrence of the error without exposing sensitive information.

- Modify the logging statement on line 168 in `nearquake/utils/__init__.py` to remove the response text.
- Ensure that the new logging statement provides enough information to understand that a JSON decoding error occurred without exposing sensitive data.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
