### PR TITLE
Potential fix for code scanning alert no. 1483: Clear-text logging of sensitive information

### DIFF
--- a/nearquake/data_processor.py
+++ b/nearquake/data_processor.py
@@ -207,7 +207,7 @@ class UploadEarthQuakeLocation(BaseDataUploader):
         content = fetch_json_data_from_url(url=url)
 
         if content is None:
-            _logger.info(f"Skipping {event}. The url returned none type. url: {url}")
+            _logger.info("Skipping event. The URL returned None type.")
             return None
 
         if content.get("error") is not None:


### PR DESCRIPTION
Potential fix for [https://github.com/dachosen1/nearquake/security/code-scanning/1483](https://github.com/dachosen1/nearquake/security/code-scanning/1483)

To fix the problem, we should avoid logging sensitive information such as latitude and longitude. Instead, we can log a more generic message that does not include the sensitive data. This can be achieved by removing the `url` and `event` details from the log message on line 210 in `nearquake/data_processor.py`.

- Replace the log message on line 210 with a more generic message that does not include sensitive data.
- Ensure that the new log message still provides useful information for debugging without exposing sensitive details.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
