### PR TITLE
Potential fix for code scanning alert no. 1482: Clear-text logging of sensitive information

### DIFF
--- a/nearquake/utils/__init__.py
+++ b/nearquake/utils/__init__.py
@@ -165,23 +165,23 @@ def fetch_json_data_from_url(url):
             return json.loads(response.text)
 
         except json.JSONDecodeError:
-            _logger.error(f"Failed to decode JSON from response: {response.text}")
+            _logger.error("Failed to decode JSON from response")
             return None
 
     except requests.exceptions.HTTPError as e:
-        _logger.error(f"HTTP error occurred while fetching data from {url}: {e}")
+        _logger.error(f"HTTP error occurred while fetching data: {e}")
         return None
 
     except requests.exceptions.ConnectionError as e:
-        _logger.error(f"Connection error occurred while fetching data from {url}: {e}")
+        _logger.error(f"Connection error occurred while fetching data: {e}")
         return None
 
     except requests.exceptions.Timeout as e:
-        _logger.error(f"Timeout error occurred while fetching data from {url}: {e}")
+        _logger.error(f"Timeout error occurred while fetching data: {e}")
         return None
 
     except requests.exceptions.RequestException as e:
-        _logger.error(f"An error occurred while fetching data from {url}: {e}")
+        _logger.error(f"An error occurred while fetching data: {e}")
         return None
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/dachosen1/nearquake/security/code-scanning/1482](https://github.com/dachosen1/nearquake/security/code-scanning/1482)

To fix the problem, we should avoid logging the full URL directly. Instead, we can log a sanitized version of the URL or a generic message that does not include sensitive information. This way, we can still provide useful logging information without exposing sensitive data.

- In the `fetch_json_data_from_url` function, replace the log messages that include the full URL with sanitized messages.
- Specifically, update the `_logger.error` calls on lines 168, 172, 176, 180, and 184 to avoid logging the full URL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
