### PR TITLE
Fix duplicate filter logic in TweetEarthquakeEvents

### DIFF
--- a/nearquake/data_processor.py
+++ b/nearquake/data_processor.py
@@ -403,12 +403,6 @@ class TweetEarthquakeEvents(BaseDataUploader):
                 EventDetails.mag > EARTHQUAKE_POST_THRESHOLD,
                 func.now() - EventDetails.ts_event_utc
                 < timedelta(seconds=REPORTED_SINCE_THRESHOLD),
-                Post.id_event == None,
-            )
-            .filter(
-                EventDetails.mag > EARTHQUAKE_POST_THRESHOLD,
-                func.now() - EventDetails.ts_event_utc
-                < timedelta(seconds=REPORTED_SINCE_THRESHOLD),
                 Post.id_event.is_(None),
             )
         )


### PR DESCRIPTION
## Summary
- Remove redundant filter conditions in TweetEarthquakeEvents._extract() that were causing inefficient database queries
- Consolidate duplicate filters into a single filter using proper .is_(None) syntax

## Changes
- Fixed duplicate filter logic in `/nearquake/data_processor.py:402-413`
- Removed redundant magnitude and timestamp filters
- Standardized null checking to use `.is_(None)` instead of `== None`

## Test plan
- [x] Verify existing tests still pass
- [x] Confirm database query efficiency improvement
- [x] Validate earthquake event extraction still works correctly