### PR TITLE
Fix CloudFormation deployment failures

### DIFF
--- a/aws-infrastructure.yml
+++ b/aws-infrastructure.yml
@@ -23,227 +23,6 @@ Parameters:
     Description: GitHub repository name
 
 Resources:
-  # GitHub Actions OIDC Provider
-  GitHubOIDCProvider:
-    Type: AWS::IAM::OIDCProvider
-    Properties:
-      Url: https://token.actions.githubusercontent.com
-      ClientIdList:
-        - sts.amazonaws.com
-      ThumbprintList:
-        - 6938fd4d98bab03faadb97b34396831e3780aea1
-        - 1c58a3a8518e8759bf075b76b750d4f2df264fcd
-      Tags:
-        - Key: Name
-          Value: !Sub "${ProjectName}-github-oidc-provider"
-
-  # GitHub Actions Role
-  GitHubActionsRole:
-    Type: AWS::IAM::Role
-    Properties:
-      RoleName: !Sub "${ProjectName}-github-actions-role"
-      AssumeRolePolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Effect: Allow
-            Principal:
-              Federated: !Ref GitHubOIDCProvider
-            Action: sts:AssumeRoleWithWebIdentity
-            Condition:
-              StringEquals:
-                token.actions.githubusercontent.com:aud: sts.amazonaws.com
-              StringLike:
-                token.actions.githubusercontent.com:sub: !Sub "repo:${GitHubOrg}/${GitHubRepo}:*"
-      Policies:
-        - PolicyName: GitHubActionsDeploymentPolicy
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Sid: CloudFormationAccess
-                Effect: Allow
-                Action:
-                  - cloudformation:CreateStack
-                  - cloudformation:UpdateStack
-                  - cloudformation:DeleteStack
-                  - cloudformation:DescribeStacks
-                  - cloudformation:DescribeStackEvents
-                  - cloudformation:DescribeStackResources
-                  - cloudformation:GetTemplate
-                  - cloudformation:GetTemplateSummary
-                  - cloudformation:CreateChangeSet
-                  - cloudformation:DescribeChangeSet
-                  - cloudformation:ExecuteChangeSet
-                Resource:
-                  - !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${ProjectName}-infrastructure/*"
-                  - !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:changeSet/*"
-              - Sid: CloudFormationValidate
-                Effect: Allow
-                Action:
-                  - cloudformation:ValidateTemplate
-                Resource: "*"
-              - Sid: ECRAccess
-                Effect: Allow
-                Action:
-                  - ecr:GetAuthorizationToken
-                  - ecr:BatchCheckLayerAvailability
-                  - ecr:GetDownloadUrlForLayer
-                  - ecr:BatchGetImage
-                  - ecr:PutImage
-                  - ecr:InitiateLayerUpload
-                  - ecr:UploadLayerPart
-                  - ecr:CompleteLayerUpload
-                  - ecr:DescribeRepositories
-                  - ecr:ListImages
-                  - ecr:CreateRepository
-                Resource: "*"
-              - Sid: IAMRoleManagement
-                Effect: Allow
-                Action:
-                  - iam:GetRole
-                  - iam:CreateRole
-                  - iam:DeleteRole
-                  - iam:PutRolePolicy
-                  - iam:DeleteRolePolicy
-                  - iam:GetRolePolicy
-                  - iam:TagRole
-                  - iam:UntagRole
-                  - iam:ListRoleTags
-                Resource:
-                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/${ProjectName}-*"
-              - Sid: IAMOIDCProviderManagement
-                Effect: Allow
-                Action:
-                  - iam:CreateOpenIDConnectProvider
-                  - iam:GetOpenIDConnectProvider
-                  - iam:DeleteOpenIDConnectProvider
-                  - iam:TagOpenIDConnectProvider
-                  - iam:UntagOpenIDConnectProvider
-                Resource:
-                  - !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/token.actions.githubusercontent.com"
-              - Sid: IAMPassRole
-                Effect: Allow
-                Action:
-                  - iam:PassRole
-                Resource:
-                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/${ProjectName}-*"
-                Condition:
-                  StringEquals:
-                    iam:PassedToService:
-                      - ecs-tasks.amazonaws.com
-                      - events.amazonaws.com
-                      - batch.amazonaws.com
-              - Sid: IAMManagedPolicyAttachment
-                Effect: Allow
-                Action:
-                  - iam:AttachRolePolicy
-                  - iam:DetachRolePolicy
-                Resource:
-                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/${ProjectName}-*"
-                Condition:
-                  ArnEquals:
-                    iam:PolicyArn:
-                      - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
-              - Sid: STSAccess
-                Effect: Allow
-                Action:
-                  - sts:GetCallerIdentity
-                Resource: "*"
-              - Sid: EC2VPCManagement
-                Effect: Allow
-                Action:
-                  - ec2:CreateVpc
-                  - ec2:DeleteVpc
-                  - ec2:DescribeVpcs
-                  - ec2:ModifyVpcAttribute
-                  - ec2:CreateSubnet
-                  - ec2:DeleteSubnet
-                  - ec2:DescribeSubnets
-                  - ec2:ModifySubnetAttribute
-                  - ec2:CreateInternetGateway
-                  - ec2:DeleteInternetGateway
-                  - ec2:AttachInternetGateway
-                  - ec2:DetachInternetGateway
-                  - ec2:DescribeInternetGateways
-                  - ec2:CreateRouteTable
-                  - ec2:DeleteRouteTable
-                  - ec2:DescribeRouteTables
-                  - ec2:CreateRoute
-                  - ec2:DeleteRoute
-                  - ec2:ReplaceRoute
-                  - ec2:AssociateRouteTable
-                  - ec2:DisassociateRouteTable
-                  - ec2:CreateSecurityGroup
-                  - ec2:DeleteSecurityGroup
-                  - ec2:DescribeSecurityGroups
-                  - ec2:AuthorizeSecurityGroupIngress
-                  - ec2:AuthorizeSecurityGroupEgress
-                  - ec2:RevokeSecurityGroupIngress
-                  - ec2:RevokeSecurityGroupEgress
-                  - ec2:CreateTags
-                  - ec2:DeleteTags
-                  - ec2:DescribeAvailabilityZones
-                  - ec2:AssociateVpcCidrBlock
-                  - ec2:DisassociateVpcCidrBlock
-                  - ec2:DescribeVpcAttribute
-                Resource: "*"
-              - Sid: BatchManagement
-                Effect: Allow
-                Action:
-                  - batch:CreateComputeEnvironment
-                  - batch:UpdateComputeEnvironment
-                  - batch:DeleteComputeEnvironment
-                  - batch:DescribeComputeEnvironments
-                  - batch:CreateJobQueue
-                  - batch:UpdateJobQueue
-                  - batch:DeleteJobQueue
-                  - batch:DescribeJobQueues
-                  - batch:RegisterJobDefinition
-                  - batch:DeregisterJobDefinition
-                  - batch:DescribeJobDefinitions
-                  - batch:TagResource
-                  - batch:UntagResource
-                  - batch:ListTagsForResource
-                Resource: "*"
-              - Sid: LogsManagement
-                Effect: Allow
-                Action:
-                  - logs:CreateLogGroup
-                  - logs:DeleteLogGroup
-                  - logs:DescribeLogGroups
-                  - logs:PutRetentionPolicy
-                  - logs:DeleteRetentionPolicy
-                  - logs:TagLogGroup
-                  - logs:UntagLogGroup
-                  - logs:ListTagsLogGroup
-                Resource:
-                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/batch/${ProjectName}*"
-              - Sid: EventBridgeManagement
-                Effect: Allow
-                Action:
-                  - events:PutRule
-                  - events:DeleteRule
-                  - events:DescribeRule
-                  - events:EnableRule
-                  - events:DisableRule
-                  - events:PutTargets
-                  - events:RemoveTargets
-                  - events:ListTargetsByRule
-                  - events:TagResource
-                  - events:UntagResource
-                  - events:ListTagsForResource
-                Resource:
-                  - !Sub "arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/${ProjectName}-*"
-              - Sid: SecretsManagerAccess
-                Effect: Allow
-                Action:
-                  - secretsmanager:GetSecretValue
-                  - secretsmanager:DescribeSecret
-                Resource:
-                  - !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:nearquake/*"
-      Tags:
-        - Key: Name
-          Value: !Sub "${ProjectName}-github-actions-role"
-
   # AWS Batch Compute Environment (Spot)
   BatchComputeEnvironment:
     Type: AWS::Batch::ComputeEnvironment
@@ -359,7 +138,7 @@ Resources:
       VpcId: !Ref VPC
       AvailabilityZone: !Select [0, !GetAZs '']
       CidrBlock: 10.0.1.0/24
-      Ipv6CidrBlock: !Select [0, !Cidr [!Select [0, !GetAtt VPC.Ipv6CidrBlocks], 256, 8]]
+      Ipv6CidrBlock: !Select [0, !Cidr [!Select [0, !GetAtt VPC.Ipv6CidrBlocks], 256, 64]]
       MapPublicIpOnLaunch: true
       AssignIpv6AddressOnCreation: true
       Tags:
@@ -373,7 +152,7 @@ Resources:
       VpcId: !Ref VPC
       AvailabilityZone: !Select [1, !GetAZs '']
       CidrBlock: 10.0.2.0/24
-      Ipv6CidrBlock: !Select [1, !Cidr [!Select [0, !GetAtt VPC.Ipv6CidrBlocks], 256, 8]]
+      Ipv6CidrBlock: !Select [1, !Cidr [!Select [0, !GetAtt VPC.Ipv6CidrBlocks], 256, 64]]
       MapPublicIpOnLaunch: true
       AssignIpv6AddressOnCreation: true
       Tags:
@@ -687,12 +466,6 @@ Resources:
             JobDefinition: !Ref FunFactJobDefinition
 
 Outputs:
-  GitHubActionsRoleArn:
-    Description: ARN of the GitHub Actions IAM Role
-    Value: !GetAtt GitHubActionsRole.Arn
-    Export:
-      Name: !Sub "${ProjectName}-github-actions-role-arn"
-
   ECRRepositoryURI:
     Description: ECR Repository URI
     Value: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${ECRRepositoryName}"


### PR DESCRIPTION
## Summary
Resolves stack update failures caused by resource conflicts and IPv6 configuration issues.

## Context
The deployment was failing due to:
- GitHubOIDCProvider and GitHubActionsRole already existing outside CloudFormation (error 409)
- Invalid IPv6 CIDR block configuration using /8 instead of /64 subnet masks

## Changes
- Removed GitHubOIDCProvider and GitHubActionsRole resources (now managed externally)
- Fixed IPv6 CIDR configuration for PublicSubnet1 and PublicSubnet2
- Removed GitHubActionsRoleArn output

🤖 Generated with [Claude Code](https://claude.com/claude-code)