### PR TITLE
Downgrade Python version from 3.14.0 to 3.13.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for better caching
-FROM python:3.14.0-slim AS base
+FROM python:3.13.5-slim AS base
 
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv


### PR DESCRIPTION
## Summary
- Revert Python base image from 3.14.0-slim to 3.13.5-slim in Dockerfile

## Reason
Python 3.14.0 was recently released and may have:
- Compatibility issues with existing dependencies
- Stability concerns as an early release
- Potential breaking changes not yet addressed in the codebase

## Changes
- Updated Dockerfile to use `python:3.13.5-slim` instead of `python:3.14.0-slim`

## Test plan
- [ ] Build Docker image successfully
- [ ] Run all tests in container
- [ ] Verify all dependencies install correctly
- [ ] Deploy to staging environment
- [ ] Monitor for any runtime issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)