### PR TITLE
Enhance earthquake tweet format with narrative style and hashtags

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
 [dependency-groups]
 dev = [
     "pytest>=8.0.0",
-    "pytest-cov>=4.0.0", 
+    "pytest-cov>=4.0.0",
     "black>=23.0.0",
     "isort>=5.0.0",
+    "python-dotenv>=1.0.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -866,6 +866,7 @@ dev = [
     { name = "isort" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "python-dotenv" },
 ]
 
 [package.metadata]
@@ -892,6 +893,7 @@ dev = [
     { name = "isort", specifier = ">=5.0.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
+    { name = "python-dotenv", specifier = ">=1.0.0" },
 ]
 
 [[package]]
@@ -1255,6 +1257,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
This PR transforms earthquake alerts from a technical bullet-point format to a more engaging narrative style that improves user engagement and social media discoverability.

### Before
```
🌍 M 4.7 - 104 km ENE of Miyako, Japan
🕐 00:50:41 UTC (54 min ago)

🔗 Full details: https://earthquake.usgs.gov/earthquakes/eventpage/us6000rvkz/executive
In an #earthquake, use stairs, not elevators! 🚶‍♂️🚶‍♀ #safetyfirst. Data provided by #usgs
```

### After
```
🌍 #RecentEarthquake: A magnitude 4.7 earthquake occurred 104 km ENE of Miyako, Japan at 00:50:41 UTC (54 min ago).
🙋 120 people reported feeling it!

🔗 Full details: https://earthquake.usgs.gov/earthquakes/eventpage/us6000rvkz/executive
How do you prepare? Share tips and stay safe! #EarthquakePrep. Data provided by #USGS
```

## Changes
- ✨ Add `#RecentEarthquake` hashtag for better discoverability
- 📝 Convert to narrative format: "A magnitude X earthquake occurred [location] at [time] UTC ([time ago])"
- 🏷️ Improve hashtag formatting (#USGS, #SafetyFirst, #Earthquake)
- 😀 Maintain contextual emojis based on magnitude
- 📊 Include felt reports when available for increased engagement
- 💬 Add different CTAs for different magnitude levels (5.5+ asks for location reports)

## Additional Fixes
- 🐛 Fix pre-existing bugs in `test_get_earthquake_image_url` tests
- 📦 Add `python-dotenv` to dev dependencies for proper test environment support
- 🧹 Remove unused `json` import from test_utils.py
- 🔧 Fix f-string without placeholders in utils/__init__.py