### PR TITLE
Update daily and weekly post schedules to noon EST

### DIFF
--- a/aws-infrastructure.yml
+++ b/aws-infrastructure.yml
@@ -409,8 +409,8 @@ Resources:
     Type: AWS::Events::Rule
     Properties:
       Name: !Sub "${ProjectName}-daily-schedule"
-      Description: "Run daily earthquake summary at 12:00 PM UTC"
-      ScheduleExpression: "cron(0 12 * * ? *)"
+      Description: "Run daily earthquake summary at 12:00 PM EST (5:00 PM UTC)"
+      ScheduleExpression: "cron(0 17 * * ? *)"
       State: ENABLED
       Targets:
         - Arn: !Sub "arn:aws:batch:${AWS::Region}:${AWS::AccountId}:job-queue/${ProjectName}-job-queue-spot"
@@ -424,7 +424,7 @@ Resources:
     Type: AWS::Events::Rule
     Properties:
       Name: !Sub "${ProjectName}-weekly-schedule"
-      Description: "Run weekly earthquake summary at 5:00 PM UTC on Mondays"
+      Description: "Run weekly earthquake summary at 12:00 PM EST (5:00 PM UTC) on Mondays"
       ScheduleExpression: "cron(0 17 ? * MON *)"
       State: ENABLED
       Targets:


### PR DESCRIPTION
## Summary
- Updated daily earthquake summary schedule from 12:00 PM UTC to 5:00 PM UTC (noon EST)
- Clarified weekly earthquake summary description to reflect noon EST timing (schedule was already correct at 5:00 PM UTC)

## Changes
Both daily and weekly summaries now post at noon Eastern Standard Time (5:00 PM UTC), which will be 1:00 PM EDT during daylight saving time.

## Test plan
- [ ] Validate CloudFormation template syntax
- [ ] Deploy infrastructure updates to AWS
- [ ] Verify EventBridge rules are updated with new schedules
- [ ] Monitor first scheduled run at new time