### PR TITLE
Make BlueSky links tappable via richtext facets

### DIFF
--- a/nearquake/post_manager.py
+++ b/nearquake/post_manager.py
@@ -1,20 +1,108 @@
 import logging
+import re
 from abc import ABC, abstractmethod
 from io import BytesIO
 
 import tweepy
-from atproto import Client
+from atproto import Client, models
 
 from nearquake.app.db import Post
-from nearquake.config import BLUESKY_PASSWORD, BLUESKY_USER_NAME, TWITTER_AUTHENTICATION
-from nearquake.utils.logging_utils import (
-    get_logger,
-    log_db_operation,
-    log_error,
-    log_info,
-)
+from nearquake.config import (BLUESKY_PASSWORD, BLUESKY_USER_NAME,
+                              TWITTER_AUTHENTICATION)
+from nearquake.utils.logging_utils import (get_logger, log_db_operation,
+                                           log_error, log_info)
 
 _logger = get_logger(__name__)
+
+# Full http(s) URLs. Kept permissive so query strings / fragments are captured;
+# trailing punctuation is stripped separately below.
+_URL_RE = re.compile(rb"https?://[A-Za-z0-9\-._~:/?#\[\]@!$&'()*+,;=%]+")
+
+# Hashtags preceded by start-of-string or whitespace. The captured group excludes
+# the leading boundary so byte offsets point at the "#...".
+_HASHTAG_RE = re.compile(rb"(?:^|\s)(#[A-Za-z0-9_]+)")
+
+# Bare domains such as "earthquake.usgs.gov" that appear without a scheme. The
+# negative lookbehind avoids matching inside a full URL, email, or handle.
+_BARE_DOMAIN_RE = re.compile(
+    rb"(?<![/@.\w])((?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+"
+    rb"(?:gov|com|org|net|edu|io))\b",
+    re.IGNORECASE,
+)
+
+# Punctuation that commonly trails a URL in prose but is not part of the link.
+_TRAILING_PUNCTUATION = b".,;:!?)]}'\""
+
+
+def _strip_trailing_punctuation(start: int, end: int, text_bytes: bytes) -> int:
+    """Trim trailing sentence punctuation from a matched byte range."""
+    while end > start and text_bytes[end - 1] in _TRAILING_PUNCTUATION:
+        end -= 1
+    return end
+
+
+def build_bluesky_facets(text: str) -> list:
+    """
+    Build BlueSky richtext facets so URLs, bare domains, and hashtags render as
+    tappable links instead of plain text.
+
+    BlueSky/AT Protocol does not auto-detect links the way Twitter does. Each
+    link must be described by a facet: a byte range (UTF-8 offsets into the post
+    text) paired with a feature (a link URI or a tag). Byte offsets are used
+    rather than character offsets, which matters because the posts contain
+    multi-byte emoji (e.g. 🌎, 🔗).
+
+    :param text: The post text to scan for links and hashtags.
+    :return: A list of ``models.AppBskyRichtextFacet.Main`` facets. Empty if
+        nothing linkable is found.
+    """
+    text_bytes = text.encode("utf-8")
+    facets = []
+    matched_ranges = []
+
+    def _add_facet(start: int, end: int, feature) -> None:
+        facets.append(
+            models.AppBskyRichtextFacet.Main(
+                index=models.AppBskyRichtextFacet.ByteSlice(
+                    byte_start=start, byte_end=end
+                ),
+                features=[feature],
+            )
+        )
+        matched_ranges.append((start, end))
+
+    def _overlaps(start: int, end: int) -> bool:
+        return any(start < r_end and end > r_start for r_start, r_end in matched_ranges)
+
+    # Full URLs first so bare-domain detection can skip anything already linked.
+    for match in _URL_RE.finditer(text_bytes):
+        start = match.start()
+        end = _strip_trailing_punctuation(start, match.end(), text_bytes)
+        uri = text_bytes[start:end].decode("utf-8")
+        _add_facet(start, end, models.AppBskyRichtextFacet.Link(uri=uri))
+
+    # Bare domains (e.g. "earthquake.usgs.gov"): keep the short display text but
+    # point the link at the https:// version.
+    for match in _BARE_DOMAIN_RE.finditer(text_bytes):
+        start, end = match.start(1), match.end(1)
+        if _overlaps(start, end):
+            continue
+        domain = text_bytes[start:end].decode("utf-8")
+        _add_facet(
+            start,
+            end,
+            models.AppBskyRichtextFacet.Link(uri=f"https://{domain}"),
+        )
+
+    # Hashtags -> tag facets (tag value excludes the leading '#').
+    for match in _HASHTAG_RE.finditer(text_bytes):
+        start, end = match.start(1), match.end(1)
+        if _overlaps(start, end):
+            continue
+        tag = text_bytes[start + 1 : end].decode("utf-8")
+        _add_facet(start, end, models.AppBskyRichtextFacet.Tag(tag=tag))
+
+    return facets
 
 
 class PlatformPoster(ABC):
@@ -143,7 +231,10 @@ class BlueSkyPost(PlatformPoster):
 
     def post(self, post_text: str, media_data: bytes = None) -> bool:
         try:
-            self.client.send_post(text=post_text)
+            # BlueSky does not auto-link URLs or hashtags; attach richtext facets
+            # so they render as tappable links.
+            facets = build_bluesky_facets(post_text)
+            self.client.send_post(text=post_text, facets=facets or None)
             log_info(_logger, f"Successfully posted to BlueSky: {post_text}")
             return True
         except Exception as e:
@@ -216,9 +307,7 @@ def post_and_save_tweet(
         in_reply_to_tweet_id=in_reply_to_tweet_id,
     )
     # Only persist to DB if at least one platform succeeded, so failed posts can be retried
-    any_succeeded = any(
-        (v is not None and v is not False) for v in results.values()
-    )
+    any_succeeded = any((v is not None and v is not False) for v in results.values())
     if any_succeeded:
         save_tweet_to_db(text, conn)
     else:

--- a/nearquake/test/test_post_manager.py
+++ b/nearquake/test/test_post_manager.py
@@ -3,14 +3,21 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from nearquake.app.db import Post
-from nearquake.post_manager import (
-    BlueSkyPost,
-    PlatformPoster,
-    TwitterPost,
-    post_and_save_tweet,
-    post_to_all_platforms,
-    save_tweet_to_db,
-)
+from nearquake.post_manager import (BlueSkyPost, PlatformPoster, TwitterPost,
+                                    build_bluesky_facets, post_and_save_tweet,
+                                    post_to_all_platforms, save_tweet_to_db)
+
+
+def _facet_kind(feature):
+    """Return the link URI or '#'-prefixed tag for a facet feature."""
+    return getattr(feature, "uri", None) or f"#{feature.tag}"
+
+
+def _decode(text, facet):
+    """Return the substring of ``text`` covered by a facet's byte range."""
+    return text.encode("utf-8")[facet.index.byte_start : facet.index.byte_end].decode(
+        "utf-8"
+    )
 
 
 class TestPlatformPoster:
@@ -91,9 +98,28 @@ class TestBlueSkyPost:
             bluesky_post = BlueSkyPost()
             result = bluesky_post.post("Test post")
 
-            # Verify the post was successful
+            # Verify the post was successful. Plain text with no links -> facets=None
             assert result is True
-            mock_client_instance.send_post.assert_called_once_with(text="Test post")
+            mock_client_instance.send_post.assert_called_once_with(
+                text="Test post", facets=None
+            )
+
+    def test_post_attaches_facets_for_links(self):
+        # A post containing a URL and a hashtag should be sent with facets so
+        # BlueSky renders them as tappable links.
+        with patch("nearquake.post_manager.Client") as mock_client:
+            mock_client_instance = MagicMock()
+            mock_client.return_value = mock_client_instance
+
+            bluesky_post = BlueSkyPost()
+            text = "See https://earthquake.usgs.gov/events/abc #Earthquake"
+            result = bluesky_post.post(text)
+
+            assert result is True
+            _, kwargs = mock_client_instance.send_post.call_args
+            assert kwargs["text"] == text
+            facets = kwargs["facets"]
+            assert facets is not None and len(facets) == 2
 
     def test_post_failure(self):
         # Get the global mock from conftest.py
@@ -109,7 +135,9 @@ class TestBlueSkyPost:
 
             # Verify the post failed but didn't raise an exception
             assert result is False
-            mock_client_instance.send_post.assert_called_once_with(text="Test post")
+            mock_client_instance.send_post.assert_called_once_with(
+                text="Test post", facets=None
+            )
 
 
 def test_save_tweet_to_db_success():
@@ -152,6 +180,90 @@ def test_post_to_all_platforms(mock_platform):
 
     mock_twitter.post.assert_called_once_with("Test message", None, None)
     mock_bluesky.post.assert_called_once_with("Test message", None)
+
+
+class TestBuildBlueSkyFacets:
+    def test_no_links_returns_empty(self):
+        assert build_bluesky_facets("Just some plain text, nothing to link.") == []
+
+    def test_full_url_facet(self):
+        text = "🔗 Full details: https://earthquake.usgs.gov/earthquakes/eventpage/us6000thkg/executive"
+        facets = build_bluesky_facets(text)
+
+        assert len(facets) == 1
+        facet = facets[0]
+        # Byte range must map back to exactly the URL (emoji is multi-byte).
+        assert (
+            _decode(text, facet)
+            == "https://earthquake.usgs.gov/earthquakes/eventpage/us6000thkg/executive"
+        )
+        assert (
+            _facet_kind(facet.features[0])
+            == "https://earthquake.usgs.gov/earthquakes/eventpage/us6000thkg/executive"
+        )
+
+    def test_url_trailing_punctuation_excluded(self):
+        text = "Read more at https://example.com/page."
+        facets = build_bluesky_facets(text)
+
+        assert len(facets) == 1
+        # The trailing period is not part of the link.
+        assert _decode(text, facets[0]) == "https://example.com/page"
+        assert _facet_kind(facets[0].features[0]) == "https://example.com/page"
+
+    def test_bare_domain_links_to_https(self):
+        text = "#Earthquake #SeismicActivity\nData: earthquake.usgs.gov"
+        facets = build_bluesky_facets(text)
+
+        domain_facets = [
+            f
+            for f in facets
+            if _facet_kind(f.features[0]) == "https://earthquake.usgs.gov"
+        ]
+        assert len(domain_facets) == 1
+        # Display text stays short; only the link target gains the scheme.
+        assert _decode(text, domain_facets[0]) == "earthquake.usgs.gov"
+
+    def test_hashtag_facets(self):
+        text = "Big news #RecentEarthquake and #USGS today"
+        facets = build_bluesky_facets(text)
+
+        tags = {f.features[0].tag for f in facets}
+        assert tags == {"RecentEarthquake", "USGS"}
+        for f in facets:
+            # Displayed range still includes the leading '#'.
+            assert _decode(text, f).startswith("#")
+
+    def test_domain_inside_url_not_double_linked(self):
+        # The bare-domain matcher must not re-link the host of a full URL.
+        text = "Details: https://earthquake.usgs.gov/events/abc"
+        facets = build_bluesky_facets(text)
+
+        assert len(facets) == 1
+        assert _facet_kind(facets[0].features[0]) == (
+            "https://earthquake.usgs.gov/events/abc"
+        )
+
+    def test_event_post_all_facets(self):
+        text = (
+            "🌎 #RecentEarthquake: A magnitude 4.8 earthquake occurred "
+            "77 km SE of Atka, Alaska at 05:18:40 UTC (22 min ago).\n\n"
+            "🔗 Full details: https://earthquake.usgs.gov/earthquakes/eventpage/us6000thkg/executive\n"
+            "Remember: Drop, Cover, Hold On! #EarthquakeSafety. Data provided by #USGS"
+        )
+        facets = build_bluesky_facets(text)
+
+        kinds = [_facet_kind(f.features[0]) for f in facets]
+        assert (
+            "https://earthquake.usgs.gov/earthquakes/eventpage/us6000thkg/executive"
+            in kinds
+        )
+        assert "#RecentEarthquake" in kinds
+        assert "#EarthquakeSafety" in kinds
+        assert "#USGS" in kinds
+        # Every facet's byte range must decode cleanly (validates UTF-8 offsets).
+        for f in facets:
+            assert _decode(text, f)
 
 
 @patch("nearquake.post_manager.post_to_all_platforms")


### PR DESCRIPTION
## Problem

Links in the bot's BlueSky posts render as inert plain text — users can't tap them (see screenshot below). URLs like `https://earthquake.usgs.gov/...`, bare domains like `earthquake.usgs.gov`, and hashtags like `#RecentEarthquake` all appear as ordinary text.

## Root cause

Unlike Twitter, BlueSky / the AT Protocol does **not** auto-detect links. Every link, mention, and hashtag must be described explicitly by a **facet** — a byte-range annotation into the post text paired with a feature (a link URI or a tag). `BlueSkyPost.post()` was calling `send_post(text=post_text)` with no `facets`, so nothing was linkable.

## Fix

- Add `build_bluesky_facets(text)` in `nearquake/post_manager.py`, which scans post text and builds facets for:
  - **Full URLs** (`https://earthquake.usgs.gov/...`) → link facet, with trailing sentence punctuation trimmed.
  - **Bare domains** (`earthquake.usgs.gov` in summary posts) → link facet pointing at the `https://` version while keeping the short display text.
  - **Hashtags** (`#RecentEarthquake`, `#USGS`, ...) → tag facets.
- Wire it into `BlueSkyPost.post()`: `send_post(text=post_text, facets=facets or None)`.
- Overlap tracking prevents a URL's host from being double-linked as a bare domain.

### Byte offsets, not character offsets

Facet ranges are computed on the UTF-8 encoded bytes of the text. This matters because the posts contain multi-byte emoji (🌎, 🔗); using character indices would misalign every link that follows an emoji.

## Testing

- New `TestBuildBlueSkyFacets` covers full URLs, trailing punctuation, bare domains, hashtags, URL/domain overlap, and a full event post with emoji (verifying byte ranges decode back to the exact link text).
- Updated existing `BlueSkyPost` tests for the new `facets=` argument and added a test asserting facets are attached when links are present.
- All 20 tests in `test_post_manager.py` pass. (One pre-existing, unrelated failure in `test_data_processor.py::test_upload_eligible_quakes` — a stale `MockQuery` — is present on `master` and untouched by this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018VjsKABAzAwGNiLvAqh27o

---
_Generated by [Claude Code](https://claude.ai/code/session_018VjsKABAzAwGNiLvAqh27o)_